### PR TITLE
Fixed hangout when pasting empty string with kitty

### DIFF
--- a/main.go
+++ b/main.go
@@ -199,7 +199,7 @@ func paste() error {
 				}
 				buf = append(buf, b)
 				// Skip initial 7 bytes of response
-				if len(buf) > 9 && buf[len(buf)-2] == '\x1b' && buf[len(buf)-1] == '\\' {
+				if len(buf) >= 9 && buf[len(buf)-2] == '\x1b' && buf[len(buf)-1] == '\\' {
 					buf = buf[:len(buf)-2]
 					break
 				}


### PR DESCRIPTION
Current implementation hangs out when trying to paste an empty string with kitty terminal (using latest version 0.35.2).

This can be reproduced in kitty by doing:
```
$echo '' | xargs echo -n | echo -en "\x1b]52;c;$(base64 -w0)\x07"
$./osc paste
```

This seems to be caused by the empty string having a different implementation in kitty than alacritty.

With an empty string in the clipboard, -v option of osc paste returns:
\x1b]52;c;\x07          (alacritty)
\x1b]52;c;\x1b\x5c  (kitty)

Check at line 202 of main.go fails to handle the second case because it only checks strings of more than 9 characters.
Switching it to len(buf) >= 9 seems to fix the issue.